### PR TITLE
Add fastInit option in document initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* The possibility to initialize a document faster (without immediately initializing the text stripper engine) on Android has been added.
+
 ## 0.3.0
 
 * A class for the PDF document information has been added. Now this information

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  pdf_text: ^0.3.0
+  pdf_text: ^0.3.1
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Pass a password for encrypted PDF documents:
 PDFDoc doc = await PDFDoc.fromFile(file, password: password);
 ```
 
+Use faster initialization on Android:
+
+```dart
+PDFDoc doc = await PDFDoc.fromFile(file, fastInit: true);
+```
+
 *Read the text of the entire document:*
 
 ```dart
@@ -113,9 +119,9 @@ allows you not to waste time loading text that you will probably not use. When y
 | Return  | Description  |
 |---|---|
 | PDFPage | **pageAt(int pageNumber)** <br> Gets the page of the document at the given page number. |
-| static Future\<PDFDoc> | **fromFile(File file, {String password = ""})** <br> Creates a PDFDoc object with a File instance. Optionally, takes a password for encrypted PDF documents.|
-| static Future\<PDFDoc> | **fromPath(String path, {String password = ""})** <br> Creates a PDFDoc object with a file path. Optionally, takes a password for encrypted PDF documents.|
-| static Future\<PDFDoc> | **fromURL(String url, {String password = ""})** <br> Creates a PDFDoc object with a url. Optionally, takes a password for encrypted PDF documents. It downloads the PDF file located in the given URL and saves it in the app's temporary directory. |
+| static Future\<PDFDoc> | **fromFile(File file, {String password = "", bool fastInit = false})** <br> Creates a PDFDoc object with a File instance. Optionally, takes a password for encrypted PDF documents. If fastInit is true, the initialization of the document will be faster on Android. In that case, the text stripper engine will not be initialized with this call, but later when some text is read. This means that the first text read will take some time but the document data can be accessed immediately.|
+| static Future\<PDFDoc> | **fromPath(String path, {String password = "", bool fastInit = false})** <br> Creates a PDFDoc object with a file path. Optionally, takes a password for encrypted PDF documents. If fastInit is true, the initialization of the document will be faster on Android. In that case, the text stripper engine will not be initialized with this call, but later when some text is read. This means that the first text read will take some time but the document data can be accessed immediately.|
+| static Future\<PDFDoc> | **fromURL(String url, {String password = "", bool fastInit = false})** <br> Creates a PDFDoc object with a url. Optionally, takes a password for encrypted PDF documents. If fastInit is true, the initialization of the document will be faster on Android. In that case, the text stripper engine will not be initialized with this call, but later when some text is read. This means that the first text read will take some time but the document data can be accessed immediately. It downloads the PDF file located in the given URL and saves it in the app's temporary directory. |
 | void | **deleteFile()** <br> Deletes the file related to this PDFDoc.<br>Throws an exception if the FileSystemEntity cannot be deleted. |
 | static Future | **deleteAllExternalFiles()** <br> Deletes all the files of the documents that have been imported from outside the local file system (e.g. using fromURL). |
 

--- a/android/src/main/kotlin/dev/aluc/pdf_text/PdfTextPlugin.kt
+++ b/android/src/main/kotlin/dev/aluc/pdf_text/PdfTextPlugin.kt
@@ -63,7 +63,8 @@ public class PdfTextPlugin: FlutterPlugin, MethodCallHandler {
             val args = call.arguments as Map<String, Any>
             val path = args["path"] as String
             val password = args["password"] as String
-            initDoc(result, path, password)
+            val fastInit = args["fastInit"] as Boolean
+            initDoc(result, path, password, fastInit)
           }
           "getDocPageText" -> {
             val args = call.arguments as Map<String, Any>
@@ -93,8 +94,8 @@ public class PdfTextPlugin: FlutterPlugin, MethodCallHandler {
   /**
     Initializes the PDF document and returns some information into the channel.
    */
-  private fun initDoc(result: Result, path: String, password: String) {
-    val doc = getDoc(result, path, password) ?: return
+  private fun initDoc(result: Result, path: String, password: String, fastInit: Boolean) {
+    val doc = getDoc(result, path, password, !fastInit) ?: return
     // Getting the length of the PDF document in pages.
     val length = doc.numberOfPages
 
@@ -173,8 +174,10 @@ public class PdfTextPlugin: FlutterPlugin, MethodCallHandler {
 
   /**
   Gets a PDF document, given its path.
+  Initializes the text stripper engine if initTextStripper is true.
    */
-  private fun getDoc(result: Result, path: String, password: String = ""): PDDocument? {
+  private fun getDoc(result: Result, path: String, password: String = "",
+    initTextStripper: Boolean = true): PDDocument? {
     // Checking for cached document
     if (cachedDoc != null && cachedDocPath == path) {
       return cachedDoc
@@ -183,7 +186,9 @@ public class PdfTextPlugin: FlutterPlugin, MethodCallHandler {
       val doc = PDDocument.load(File(path), password)
       cachedDoc = doc
       cachedDocPath = path
-      initTextStripperEngine(doc)
+      if (initTextStripper) {
+        initTextStripperEngine(doc)
+      }
       doc
     } catch (e: Exception) {
       Handler(Looper.getMainLooper()).post {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -143,7 +143,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.3.1"
   pedantic:
     dependency: transitive
     description:

--- a/lib/pdf_text.dart
+++ b/lib/pdf_text.dart
@@ -19,14 +19,20 @@ class PDFDoc {
   PDFDoc._internal();
 
   /// Creates a [PDFDoc] object with a [File] instance.
-  /// Optionally, takes a password for encrypted PDF documents.
-  static Future<PDFDoc> fromFile(File file, {String password = ""}) async {
+  /// Optionally, takes a [password] for encrypted PDF documents.
+  /// If [fastInit] is true, the initialization of the document will
+  /// be faster on Android. In that case, the text stripper engine
+  /// will not be initialized with this call, but later when some text
+  /// is read. This means that the first text read will take some time
+  /// but the document data can be accessed immediately.
+  static Future<PDFDoc> fromFile(File file,
+      {String password = "", bool fastInit = false}) async {
     var doc = PDFDoc._internal();
     doc._file = file;
     Map data;
     try {
-      data = await _CHANNEL
-          .invokeMethod('initDoc', {"path": file.path, "password": password});
+      data = await _CHANNEL.invokeMethod('initDoc',
+          {"path": file.path, "password": password, "fastInit": fastInit});
     } on Exception catch (e) {
       return Future.error(e);
     }
@@ -39,16 +45,28 @@ class PDFDoc {
   }
 
   /// Creates a [PDFDoc] object with a file path.
-  /// Optionally, takes a password for encrypted PDF documents.
-  static Future<PDFDoc> fromPath(String path, {String password = ""}) async {
-    return await fromFile(File(path), password: password);
+  /// Optionally, takes a [password] for encrypted PDF documents.
+  /// If [fastInit] is true, the initialization of the document will
+  /// be faster on Android. In that case, the text stripper engine
+  /// will not be initialized with this call, but later when some text
+  /// is read. This means that the first text read will take some time
+  /// but the document data can be accessed immediately.
+  static Future<PDFDoc> fromPath(String path,
+      {String password = "", bool fastInit = false}) async {
+    return await fromFile(File(path), password: password, fastInit: fastInit);
   }
 
   /// Creates a [PDFDoc] object with a URL.
-  /// Optionally, takes a password for encrypted PDF documents.
+  /// Optionally, takes a [password] for encrypted PDF documents.
+  /// If [fastInit] is true, the initialization of the document will
+  /// be faster on Android. In that case, the text stripper engine
+  /// will not be initialized with this call, but later when some text
+  /// is read. This means that the first text read will take some time
+  /// but the document data can be accessed immediately.
   /// It downloads the PDF file located in the given URL and saves it
   /// in the app's temporary directory.
-  static Future<PDFDoc> fromURL(String url, {String password = ""}) async {
+  static Future<PDFDoc> fromURL(String url,
+      {String password = "", bool fastInit = false}) async {
     File file;
     try {
       String tempDirPath = (await getTemporaryDirectory()).path;
@@ -62,7 +80,7 @@ class PDFDoc {
     } on Exception catch (e) {
       return Future.error(e);
     }
-    return await fromFile(file, password: password);
+    return await fromFile(file, password: password, fastInit: fastInit);
   }
 
   /// Gets the page of the document at the given page number.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdf_text
 description: This plugin for Flutter allows you to read the text content of PDF documents and convert it into strings. It works on iOS and Android.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/AlessioLuciani/flutter-pdf-text
 
 environment:


### PR DESCRIPTION
Using this option it can be decided whether to initialize the text stripper engine on Android immediately or at the first text read.
fixes #13